### PR TITLE
Updating POM to resolve issue in build process with newer JDK [FIXED JENKINS-17268]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>plugin</artifactId>
-		<groupId>org.jvnet.hudson.plugins</groupId>
+		<groupId>org.jenkins-ci.plugins</groupId>
 		<version>1.500</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>plugin</artifactId>
 		<groupId>org.jvnet.hudson.plugins</groupId>
-		<version>1.357</version>
+		<version>1.500</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Current build is failing because a library used doesn't work on latest version of java.
Updating POM to build against a newer version of Jenkins that has removed that library