### PR TITLE
Correct `pom.xml` by adding `changelist` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <version>${changelist}</version>
 
   <properties>
-    <version>${changelist}</version>
+    <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>


### PR DESCRIPTION
With the recent Maven upgrade to 3.9.10 by infra (week of 2025-06-09), the bom release build on 2025-06-13 started failing with the following error:

```
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'version' must be a constant version but is '${changelist}'. @ line 14, column 12
```

Prior to Maven 3.9.10, all related builds were successful.

This PR corrects the issue by removing `version` from `properties` and correctly adding `changelist`.

<!-- Please describe your pull request here. -->

### Testing done

* Set Maven to `3.9.10`
* `mvn clean verify`

Before the change, when you use a Maven version < 3.9.10, everything works. However, 3.9.10 fails. With this PR, all Maven versions work.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
